### PR TITLE
fix: decouple from sofa-rpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ test/fixtures/apps/**/app/public
 test/fixtures/apps/**/app/proxy
 test/fixtures/apps/**/run
 test/fixtures/apps/**/logs
+test/fixtures/apps/**/app/proxy_class/

--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ exports.prometheus = {
 - `http_response_time_ms summary`: ms to handle a request
 - `http_request_rate counter`: number of requests to a route
 
-while egg-sofa-rpc is enabled
-- `sofa_rpc_consumer_response_time_ms summary`: ms of rpc time consuming
-- `sofa_rpc_consumer_request_rate counter`: number of rpc calls
-- `sofa_rpc_consumer_fail_response_time_ms summary`: ms of fail rpc time consuming
-- `sofa_rpc_consumer_request_fail_rate counter`: number of fail rpc calls
-- `sofa_rpc_consumer_request_size_bytes summary`: rpc request size in bytes
-- `sofa_rpc_consumer_response_size_bytes summary`: rpc response size in bytes
-- `sofa_rpc_provider_response_time_ms summary`: ms of request processed time
-- `sofa_rpc_provider_request_rate counter`: number of rpc calls
-- `sofa_rpc_provider_fail_response_time_ms summary`: ms of fail request processed time
-- `sofa_rpc_provider_request_fail_rate counter`: number of fail rpc calls
+while egg-rpc-base is enabled
+- `rpc_consumer_response_time_ms summary`: ms of rpc time consuming
+- `rpc_consumer_request_rate counter`: number of rpc calls
+- `rpc_consumer_fail_response_time_ms summary`: ms of fail rpc time consuming
+- `rpc_consumer_request_fail_rate counter`: number of fail rpc calls
+- `rpc_consumer_request_size_bytes summary`: rpc request size in bytes
+- `rpc_consumer_response_size_bytes summary`: rpc response size in bytes
+- `rpc_provider_response_time_ms summary`: ms of request processed time
+- `rpc_provider_request_rate counter`: number of rpc calls
+- `rpc_provider_fail_response_time_ms summary`: ms of fail request processed time
+- `rpc_provider_request_fail_rate counter`: number of fail rpc calls
 
 ## Custom Metrics
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,17 +60,17 @@ exports.prometheus = {
 - `http_response_time_ms summary`: http 请求耗时
 - `http_request_rate counter`: http 请求数
 
-当 egg-sofa-rpc 插件开启时，还会提供下面 metrics
-- `sofa_rpc_consumer_response_time_ms summary`: rpc 客户端请求耗时
-- `sofa_rpc_consumer_request_rate counter`: rpc 客户端请求数
-- `sofa_rpc_consumer_fail_response_time_ms summary`: rpc 客户端失败的请求耗时
-- `sofa_rpc_consumer_request_fail_rate counter`: rpc 客户端失败的请求数
-- `sofa_rpc_consumer_request_size_bytes summary`: rpc 请求大小统计
-- `sofa_rpc_consumer_response_size_bytes summary`: rpc 响应大小统计
-- `sofa_rpc_provider_response_time_ms summary`: rpc 服务端处理时间
-- `sofa_rpc_provider_request_rate counter`: rpc 服务端收到请求数
-- `sofa_rpc_provider_fail_response_time_ms summary`: rpc 服务端失败的请求处理时间
-- `sofa_rpc_provider_request_fail_rate counter`: rpc 服务端失败的请求数
+当 egg-rpc-base 插件开启时，还会提供下面 metrics
+- `rpc_consumer_response_time_ms summary`: rpc 客户端请求耗时
+- `rpc_consumer_request_rate counter`: rpc 客户端请求数
+- `rpc_consumer_fail_response_time_ms summary`: rpc 客户端失败的请求耗时
+- `rpc_consumer_request_fail_rate counter`: rpc 客户端失败的请求数
+- `rpc_consumer_request_size_bytes summary`: rpc 请求大小统计
+- `rpc_consumer_response_size_bytes summary`: rpc 响应大小统计
+- `rpc_provider_response_time_ms summary`: rpc 服务端处理时间
+- `rpc_provider_request_rate counter`: rpc 服务端收到请求数
+- `rpc_provider_fail_response_time_ms summary`: rpc 服务端失败的请求处理时间
+- `rpc_provider_request_fail_rate counter`: rpc 服务端失败的请求数
 
 ## 自定义 Metrics
 

--- a/lib/sofa_rpc_client.js
+++ b/lib/sofa_rpc_client.js
@@ -3,40 +3,40 @@
 const { Summary, Counter } = require('prom-client');
 
 module.exports = app => {
-  if (!app.sofaRpcClient) return;
+  if (!app.rpcClient) return;
 
   const ResponseTime = new Summary({
-    name: 'sofa_rpc_consumer_response_time_ms',
+    name: 'rpc_consumer_response_time_ms',
     help: 'ms of rpc time consuming',
     labelNames: [ 'service', 'method', 'protocol', 'target_app' ],
   });
   const RequestRate = new Counter({
-    name: 'sofa_rpc_consumer_request_rate',
+    name: 'rpc_consumer_request_rate',
     help: 'number of rpc calls',
     labelNames: [ 'service', 'method', 'protocol', 'target_app' ],
   });
   const FailResponseTime = new Summary({
-    name: 'sofa_rpc_consumer_fail_response_time_ms',
+    name: 'rpc_consumer_fail_response_time_ms',
     help: 'ms of fail rpc time consuming',
     labelNames: [ 'service', 'method', 'protocol', 'target_app' ],
   });
   const FailRequestRate = new Counter({
-    name: 'sofa_rpc_consumer_request_fail_rate',
+    name: 'rpc_consumer_request_fail_rate',
     help: 'number of fail rpc calls',
     labelNames: [ 'service', 'method', 'protocol', 'target_app' ],
   });
   const RequestSize = new Summary({
-    name: 'sofa_rpc_consumer_request_size_bytes',
+    name: 'rpc_consumer_request_size_bytes',
     help: 'rpc request size in bytes',
     labelNames: [ 'service', 'method', 'protocol', 'target_app' ],
   });
   const ResponseSize = new Summary({
-    name: 'sofa_rpc_consumer_response_size_bytes',
+    name: 'rpc_consumer_response_size_bytes',
     help: 'rpc response size in bytes',
     labelNames: [ 'service', 'method', 'protocol', 'target_app' ],
   });
 
-  app.sofaRpcClient.on('request', req => {
+  app.rpcClient.on('request', req => {
     if (req.requestProps && !req.requestProps.app) {
       req.requestProps.app = app.name;
     }
@@ -50,7 +50,7 @@ module.exports = app => {
     RequestRate.inc(labels, 1);
   });
 
-  app.sofaRpcClient.on('response', ({ req }) => {
+  app.rpcClient.on('response', ({ req }) => {
     const labels = {
       service: req.serverSignature,
       method: req.methodName,

--- a/lib/sofa_rpc_server.js
+++ b/lib/sofa_rpc_server.js
@@ -3,30 +3,30 @@
 const { Summary, Counter } = require('prom-client');
 
 module.exports = app => {
-  if (!app.sofaRpcServer) return;
+  if (!app.rpcServer) return;
 
   const ResponseTime = new Summary({
-    name: 'sofa_rpc_provider_response_time_ms',
+    name: 'rpc_provider_response_time_ms',
     help: 'ms of request processed time',
     labelNames: [ 'service', 'method', 'protocol', 'caller_app' ],
   });
   const RequestRate = new Counter({
-    name: 'sofa_rpc_provider_request_rate',
+    name: 'rpc_provider_request_rate',
     help: 'number of rpc calls',
     labelNames: [ 'service', 'method', 'protocol', 'caller_app' ],
   });
   const FailResponseTime = new Summary({
-    name: 'sofa_rpc_provider_fail_response_time_ms',
+    name: 'rpc_provider_fail_response_time_ms',
     help: 'ms of fail request processed time',
     labelNames: [ 'service', 'method', 'protocol', 'caller_app' ],
   });
   const FailRequestRate = new Counter({
-    name: 'sofa_rpc_provider_request_fail_rate',
+    name: 'rpc_provider_request_fail_rate',
     help: 'number of fail rpc calls',
     labelNames: [ 'service', 'method', 'protocol', 'caller_app' ],
   });
 
-  app.sofaRpcServer.on('response', ({ req, res }) => {
+  app.rpcServer.on('response', ({ req, res }) => {
     const labels = {
       service: req.data.serverSignature,
       method: req.data.methodName,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "eggPlugin": {
     "name": "prometheus",
     "optionalDependencies": [
-      "sofaRpc"
+      "rpc"
     ]
   },
   "files": [
@@ -47,15 +47,15 @@
   "devDependencies": {
     "autod": "^3.0.1",
     "autod-egg": "^1.1.0",
-    "egg": "^2.11.2",
+    "egg": "^2.12.0",
     "egg-bin": "^4.9.0",
     "egg-mock": "^3.20.1",
-    "egg-rpc-generator": "^1.0.0",
-    "egg-sofa-rpc": "^1.0.1",
-    "eslint": "^5.6.1",
+    "egg-rpc-base": "^1.1.0",
+    "egg-rpc-generator": "^1.1.0",
+    "eslint": "^5.8.0",
     "eslint-config-egg": "^7.1.0",
     "mz-modules": "^2.1.0",
-    "urllib": "^2.30.0",
+    "urllib": "^2.31.1",
     "webstorm-disable-index": "^1.2.0"
   }
 }

--- a/test/fixtures/apps/rpc-app/config/config.default.js
+++ b/test/fixtures/apps/rpc-app/config/config.default.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.sofaRpc = {
+exports.rpc = {
   registry: {
     address: '127.0.0.1:2181',
   },

--- a/test/fixtures/apps/rpc-app/config/plugin.js
+++ b/test/fixtures/apps/rpc-app/config/plugin.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.sofaRpc = {
+exports.rpc = {
   enable: true,
-  package: 'egg-sofa-rpc',
+  package: 'egg-rpc-base',
 };

--- a/test/rpc.test.js
+++ b/test/rpc.test.js
@@ -33,16 +33,16 @@ describe('test/rpc.test.js', () => {
 
     assert(metricsStr.includes('TYPE http_response_time_ms summary'));
     assert(metricsStr.includes('TYPE http_request_rate counter'));
-    assert(metricsStr.includes('TYPE sofa_rpc_consumer_response_time_ms summary'));
-    assert(metricsStr.includes('TYPE sofa_rpc_consumer_request_rate counter'));
-    assert(metricsStr.includes('TYPE sofa_rpc_consumer_fail_response_time_ms summary'));
-    assert(metricsStr.includes('TYPE sofa_rpc_consumer_request_fail_rate counter'));
-    assert(metricsStr.includes('TYPE sofa_rpc_consumer_request_size_bytes summary'));
-    assert(metricsStr.includes('TYPE sofa_rpc_consumer_response_size_bytes summary'));
-    assert(metricsStr.includes('TYPE sofa_rpc_provider_response_time_ms summary'));
-    assert(metricsStr.includes('TYPE sofa_rpc_provider_request_rate counter'));
-    assert(metricsStr.includes('TYPE sofa_rpc_provider_fail_response_time_ms summary'));
-    assert(metricsStr.includes('TYPE sofa_rpc_provider_request_fail_rate counter'));
+    assert(metricsStr.includes('TYPE rpc_consumer_response_time_ms summary'));
+    assert(metricsStr.includes('TYPE rpc_consumer_request_rate counter'));
+    assert(metricsStr.includes('TYPE rpc_consumer_fail_response_time_ms summary'));
+    assert(metricsStr.includes('TYPE rpc_consumer_request_fail_rate counter'));
+    assert(metricsStr.includes('TYPE rpc_consumer_request_size_bytes summary'));
+    assert(metricsStr.includes('TYPE rpc_consumer_response_size_bytes summary'));
+    assert(metricsStr.includes('TYPE rpc_provider_response_time_ms summary'));
+    assert(metricsStr.includes('TYPE rpc_provider_request_rate counter'));
+    assert(metricsStr.includes('TYPE rpc_provider_fail_response_time_ms summary'));
+    assert(metricsStr.includes('TYPE rpc_provider_request_fail_rate counter'));
 
     res = await urllib.curl('http://127.0.0.1:3000/metric');
     assert(res && res.status === 404);
@@ -60,7 +60,7 @@ describe('test/rpc.test.js', () => {
     const metricsStr = res.data.toString();
     console.log(metricsStr);
 
-    assert(metricsStr.includes(`sofa_rpc_provider_request_fail_rate{service="com.alipay.sofa.rpc.protobuf.ProtoService:1.0",method="echoObj",protocol="bolt",caller_app="rpc-app",app="rpc-app",pid="${process.pid}"} 1`));
+    assert(metricsStr.includes(`rpc_provider_request_fail_rate{service="com.alipay.sofa.rpc.protobuf.ProtoService:1.0",method="echoObj",protocol="bolt",caller_app="rpc-app",app="rpc-app",pid="${process.pid}"} 1`));
 
     assert(metricsStr.includes('http_response_time_ms_count{method="GET",path="/rpc",status="200"'));
     assert(metricsStr.includes('http_response_time_ms_count{method="GET",path="/rpc",status="500"'));


### PR DESCRIPTION
去掉 sofa-rpc 的强绑定，转而依赖 rpc-base，这样所有 rpc 都可以得到默认的 metrics